### PR TITLE
wave5: improve a performance of decoder

### DIFF
--- a/drivers/media/platform/chips-media/wave5/wave5-helper.c
+++ b/drivers/media/platform/chips-media/wave5/wave5-helper.c
@@ -52,6 +52,11 @@ int wave5_vpu_release_device(struct file *filp,
 			     char *name)
 {
 	struct vpu_instance *inst = wave5_to_vpu_inst(filp->private_data);
+	if (inst->run_thread) {
+		up(&inst->run_sem);
+		kthread_stop(inst->run_thread);
+		inst->run_thread = NULL;
+	}
 
 	v4l2_m2m_ctx_release(inst->v4l2_fh.m2m_ctx);
 	if (inst->state != VPU_INST_STATE_NONE) {

--- a/drivers/media/platform/chips-media/wave5/wave5-vpu.c
+++ b/drivers/media/platform/chips-media/wave5/wave5-vpu.c
@@ -52,12 +52,11 @@ static irqreturn_t wave5_vpu_irq_thread(int irq, void *dev_id)
 	if (wave5_vdi_read_register(dev, W5_VPU_VPU_INT_STS)) {
 		irq_reason = wave5_vdi_read_register(dev, W5_VPU_VINT_REASON);
 		wave5_vdi_write_register(dev, W5_VPU_VINT_REASON_CLR, irq_reason);
+		seq_done = wave5_vdi_read_register(dev, W5_RET_SEQ_DONE_INSTANCE_INFO);
+		cmd_done = wave5_vdi_read_register(dev, W5_RET_QUEUE_CMD_DONE_INST);
 		wave5_vdi_write_register(dev, W5_VPU_VINT_CLEAR, 0x1);
 
 		list_for_each_entry(inst, &dev->instances, list) {
-			seq_done = wave5_vdi_read_register(dev, W5_RET_SEQ_DONE_INSTANCE_INFO);
-			cmd_done = wave5_vdi_read_register(dev, W5_RET_QUEUE_CMD_DONE_INST);
-
 			if (irq_reason & BIT(INT_WAVE5_INIT_SEQ) ||
 			    irq_reason & BIT(INT_WAVE5_ENC_SET_PARAM)) {
 				if (seq_done & BIT(inst->id)) {
@@ -80,6 +79,7 @@ static irqreturn_t wave5_vpu_irq_thread(int irq, void *dev_id)
 
 			wave5_vpu_clear_interrupt(inst, irq_reason);
 		}
+
 	}
 
 	return IRQ_HANDLED;

--- a/drivers/media/platform/chips-media/wave5/wave5-vpuapi.c
+++ b/drivers/media/platform/chips-media/wave5/wave5-vpuapi.c
@@ -232,7 +232,7 @@ int wave5_vpu_dec_close(struct vpu_instance *inst, u32 *fail_res)
 	}
 
 	wave5_vdi_free_dma_memory(vpu_dev, &p_dec_info->vb_task);
-
+		
 	if (!pm_runtime_suspended(inst->dev->dev))
 		pm_runtime_put_sync(inst->dev->dev);
 

--- a/drivers/media/platform/chips-media/wave5/wave5-vpuapi.h
+++ b/drivers/media/platform/chips-media/wave5/wave5-vpuapi.h
@@ -767,6 +767,11 @@ struct vpu_instance_ops {
 	void (*finish_process)(struct vpu_instance *inst);
 };
 
+struct vpu_timestamp_list {
+	struct list_head list;
+	u64 timestamp;
+};
+
 struct vpu_instance {
 	struct list_head list;
 	struct v4l2_fh v4l2_fh;
@@ -806,11 +811,15 @@ struct vpu_instance {
 	bool cbcr_interleave;
 	bool nv21;
 	bool eos;
+	bool retry;
+	int queuing_num;
+	spinlock_t feed_lock;
 	struct vpu_buf bitstream_vbuf;
 	dma_addr_t last_rd_ptr;
 	size_t remaining_consumed_bytes;
 	bool needs_reallocation;
-
+	struct semaphore run_sem;
+	struct task_struct *run_thread;
 	unsigned int min_src_buf_count;
 	unsigned int rot_angle;
 	unsigned int mirror_direction;


### PR DESCRIPTION
The existing way for decoding is to wait unit each frame is decoded after feeding a bitstream. It caused a low performance, so we changed an asynchronous way between decoding and feeding a bitstream.

Ticket : TICHA-442